### PR TITLE
Cambios en el sitio

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,5 @@ import tailwind from '@astrojs/tailwind';
 // https://astro.build/config
 export default defineConfig({
     site: 'https://jaosdev.github.io/',
-    base: '/jaosdev.github.io',
     integrations: [tailwind()]
 });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,11 +5,11 @@ import Layout from '../layouts/Layout.astro';
 
 ---
 <script src="../assets/js/main.js"></script>
-<main >
-	<Layout title='JaosDev'>
+<Layout title='JaosDev'>
+    <main>
 		
-	</Layout>
-</main>
+    </main>
+</Layout>
 
 
 


### PR DESCRIPTION
se modificó la jerarquia del elemento <main> respecto del layout #1 

se elimino una variable de la configuracion de astro

import { defineConfig } from 'astro/config'

export default defineConfig({
  site: 'https://jaosdev.github.io',
  base: 'my-repo',   <-----------------
})


esa configuración solo es necesaria en caso de usar un dominio personalizado.

se puede verificar aqui: https://docs.astro.build/en/guides/deploy/github/
en la seccion de base, "nota azul"